### PR TITLE
fix: move `Response()` into function to support Cloudflare Workers (#2)

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,7 +1,6 @@
 import type { Buffer } from "node:buffer";
 import type { TKassa } from "./index";
 import type { MaybePromise, WebhookBody } from "./utils";
-const responseOK = new Response("OK");
 
 interface FrameworkHandler {
 	body: MaybePromise<WebhookBody>;
@@ -22,7 +21,7 @@ const frameworks: Record<
 	| "koa",
 	FrameworkAdapter
 > = {
-	elysia: ({ body }) => ({ body, response: () => responseOK }),
+	elysia: ({ body }) => ({ body, response: () => new Response("OK") }),
 	fastify: (request, reply) => ({
 		body: request.body,
 		response: () => reply.send("OK"),
@@ -47,8 +46,8 @@ const frameworks: Record<
 		}),
 		response: () => res.writeHead(200).end("OK"),
 	}),
-	"std/http": (req) => ({ body: req.json(), response: () => responseOK }),
-	"Bun.serve": (req) => ({ body: req.json(), response: () => responseOK }),
+	"std/http": (req) => ({ body: req.json(), response: () => new Response("OK") }),
+	"Bun.serve": (req) => ({ body: req.json(), response: () => new Response("OK") }),
 } satisfies Record<string, FrameworkAdapter>;
 
 /**


### PR DESCRIPTION
This fixes issue #2 by moving `Response` creation into a function.
Cloudflare Workers require that global code doesn't invoke Web APIs like `Response()` at the top level.